### PR TITLE
Convert to modern cljs and revamp this library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
-lein: lein2
-script: lein2 ci
+
+script: lein ci

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:paths   ["src"]
+ :deps    {noencore {:mvn/version "0.1.20" :exclusions [org.clojure/clojure]}}
+ :aliases {:dev  {:extra-paths ["dev"]
+                  :extra-deps  {org.clojure/clojure {:mvn/version "1.9.0"}
+                                org.clojure/clojurescript {:mvn/version "1.10.339"}
+                                cider/piggieback {:mvn/version "0.3.9" :exclusions [org.clojure/clojurescript]}}}}}

--- a/project.clj
+++ b/project.clj
@@ -5,37 +5,33 @@
   :min-lein-version "2.0.0"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[noencore "0.1.20"]
-                 [org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-3165" :scope "provided"]]
-  :aliases {"cleantest" ["do" "clean," "cljx" "once," "test," "cljsbuild" "test"]
-            "ci" ["do" ["cleantest"] ["lint"]]
-            "lint" ["do"  ["eastwood"]]}
-  :cljx {:builds [{:source-paths ["src"]
-                   :output-path "target/classes"
-                   :rules :clj}
-                  {:source-paths ["src"]
-                   :output-path "target/classes"
-                   :rules :cljs}
-                  {:source-paths ["test"]
-                   :output-path "target/test-classes"
-                   :rules :clj}
-                  {:source-paths ["test"]
-                   :output-path "target/test-classes"
-                   :rules :cljs}]}
-  :cljsbuild {:builds [{:source-paths ["target/classes" "target/test-classes"]
+  :dependencies [[noencore "0.1.20" :exclusions [org.clojure/clojure]]]
+  :aliases {"phantom-test" ["with-profile" "+dev" "do" ["clean"] ["doo" "phantom" "test" "once"]]
+            "node-test" ["with-profile" "+dev" "do" ["clean"] ["doo" "node" "node-test" "once"]]
+            "cleantest" ["with-profile" "+dev" "do"
+                         ["clean"]
+                         ["doo" "phantom" "test" "once"]
+                         ["doo" "node" "node-test" "once"]]
+            "ci" ["with-profile" "+dev" "do" ["cleantest"] ["lint"]]
+            "lint" ["with-profile" "+dev" "eastwood"]}
+  :cljsbuild {:builds [{:id "test"
+                        :source-paths ["src" "test"]
                         :compiler {:output-to "target/testable.js"
+                                   :output-dir "target"
+                                   :main hal.test-runner
                                    :optimizations :advanced
-                                   :pretty-print true}}]
-              :test-commands {"node" ["node" :node-runner "target/testable.js"]
-                              "phantom" ["phantomjs" :runner "target/testable.js"]}}
+                                   :pretty-print true}}
+                       {:id "node-test"
+                        :source-paths ["src" "test"]
+                        :compiler {:output-to "target/node-testable.js"
+                                   :output-dir "target"
+                                   :main hal.test-runner
+                                   :target :nodejs}}]}
   :deploy-repositories [["releases" :clojars]]
-  :prep-tasks [["cljx" "once"] "javac" "compile"]
-  :profiles {:dev {:plugins [[com.cemerick/clojurescript.test "0.3.3"]
-                             [com.cemerick/piggieback "0.2.1"]
-                             [com.keminglabs/cljx "0.6.0"]
-                             [jonase/eastwood "0.2.1"]
-                             [lein-cljsbuild "1.0.5"]
+  :profiles {:dev {:plugins [[jonase/eastwood "0.2.1"]
+                             [lein-doo "0.1.10"]
+                             [lein-cljsbuild "1.1.7"]
                              [lein-difftest "2.0.0"]]
-                   :repl-options {:nrepl-middleware [cljx.repl-middleware/wrap-cljx]}
-                   :test-paths ["target/test-classes"]}})
+                   :dependencies [[org.clojure/clojure "1.9.0"]
+                                  [org.clojure/clojurescript "1.10.339"]
+                                  [cider/piggieback "0.3.9" :exclusions [org.clojure/clojurescript]]]}})

--- a/src/hal/core.cljc
+++ b/src/hal/core.cljc
@@ -1,7 +1,7 @@
 (ns hal.core
   (:refer-clojure :exclude [keys vals])
   (:require [clojure.string :refer [blank?]]
-            [no.en.core :refer [format-url parse-integer]]))
+            [no.en.core :as noencore]))
 
 (def ^:dynamic *defaults*
   {:page :page
@@ -55,7 +55,7 @@
 
 (defn- extract-page [req & [opts]]
   (let [k (:page (merge *defaults* opts))]
-    [k (parse-integer (get-in req [:query-params k]))]))
+    [k (noencore/parse-integer (get-in req [:query-params k]))]))
 
 (defn next-url
   "Build the URL for the next HAL resources from the Ring `request`."
@@ -63,7 +63,7 @@
   (if-not (blank? (:uri req))
     (let [[k v] (extract-page req opts)]
       (-> (assoc-in req [:query-params k] (inc (or v 1)))
-          (format-url)))))
+          (noencore/format-url)))))
 
 (defn prev-url
   "Build the URL for the previous HAL resources from the Ring `request`."
@@ -72,20 +72,20 @@
     (let [[k v] (extract-page req opts)]
       (if (and v (> v 1))
         (-> (assoc-in req [:query-params k] (dec v))
-            (format-url))))))
+            (noencore/format-url))))))
 
 (defn resource
   "Make a HAL resource for the Ring request `req` and the
   resource `res`."
   [req res & [opts]]
-  (-> (with-hrefs res :self (format-url req))))
+  (-> (with-hrefs res :self (noencore/format-url req))))
 
 (defn resources
   "Make a HAL resource for the Ring request `req` and the resources
   `coll`."
   [req name coll & [opts]]
   (-> (with-hrefs {}
-        :self (format-url req)
+        :self (noencore/format-url req)
         :next (next-url req opts)
         :prev (prev-url req opts))
       (with-embedded name coll)))

--- a/test/hal/core_test.cljc
+++ b/test/hal/core_test.cljc
@@ -1,9 +1,6 @@
 (ns hal.core-test
-  #+cljs (:require-macros [cemerick.cljs.test :refer [are is deftest testing]])
   (:require [hal.core :as hal]
-            #+clj [clojure.test :refer :all]
-            #+clj [clojure.pprint :refer [pprint]]
-            #+cljs [cemerick.cljs.test :as t]))
+            [clojure.test :as t #?(:clj :refer :cljs :refer-macros) [are is deftest testing]]))
 
 (def europe
   (hal/with-hrefs {:name "Europe"}

--- a/test/hal/test_runner.cljs
+++ b/test/hal/test_runner.cljs
@@ -1,0 +1,7 @@
+(ns hal.test-runner
+  (:require [doo.runner :as doo :include-macros true]
+            [hal.core-test]))
+
+(enable-console-print!)
+
+(doo/doo-tests 'hal.core-test)


### PR DESCRIPTION
This series of commits update the code base to work against Cljs 1.10 and make
sure tests follow along.

A `deps.edn` file is also added for SHA consumption.